### PR TITLE
fix(chaosdaemon): make ApplyHttpChaos idempotent on retry (closes #4)

### DIFF
--- a/pkg/bpm/bpm.go
+++ b/pkg/bpm/bpm.go
@@ -363,6 +363,65 @@ func (m *BackgroundProcessManager) GetUidByIdentifier(identifier string) (string
 	return uid, true
 }
 
+// IsProcessAlive returns true if BPM has a tracked process with this UID and
+// the underlying OS process is still running with the original create-time
+// (defending against PID reuse). False is returned for any of:
+//   - the UID is not registered (already recycled)
+//   - the OS process at the cached PID has exited
+//   - the OS process at the cached PID has a different create-time
+//     (PID was recycled by a different unrelated process)
+//
+// Callers such as ApplyHttpChaos use this to decide whether a "recovered"
+// uid actually points at a live tproxy or a stale BPM entry whose pipes
+// would block forever on write.
+func (m *BackgroundProcessManager) IsProcessAlive(uid string) bool {
+	proc, ok := m.getProc(uid)
+	if !ok {
+		return false
+	}
+
+	osProc, err := process.NewProcess(int32(proc.Pair.Pid))
+	if err != nil {
+		// process.NewProcess returns an error when /proc/<pid> is gone
+		return false
+	}
+
+	ct, err := osProc.CreateTime()
+	if err != nil {
+		// Process exists but we can't read its stat; treat as dead to be safe.
+		return false
+	}
+
+	// Defend against PID reuse: a different process may have grabbed the same
+	// PID after the original tproxy died. The create-time has microsecond-ish
+	// resolution and is captured at StartProcess time, so it's a reliable
+	// generation marker.
+	return ct == proc.Pair.CreateTime
+}
+
+// EvictProcess unregisters a process from BPM as if its host process had
+// exited. Use this when IsProcessAlive returned false: the death-channel
+// cleanup never fired (e.g. because cmd.Wait was blocked, or because the host
+// chaos-daemon restarted with stale state) but the OS process is gone.
+// The cleanup mirrors the deathChannel goroutine: deletes from processes,
+// pidPairToUid, and identifiers, then cancels the per-process context.
+//
+// This is a no-op if the UID is not currently registered.
+func (m *BackgroundProcessManager) EvictProcess(uid string) {
+	v, loaded := m.processes.LoadAndDelete(uid)
+	if !loaded {
+		return
+	}
+	proc := v.(*Process)
+	m.pidPairToUid.Delete(proc.Pair)
+	if proc.Cmd.Identifier != nil {
+		m.identifiers.Delete(*proc.Cmd.Identifier)
+	}
+	if proc.stopped != nil {
+		proc.stopped()
+	}
+}
+
 func (m *BackgroundProcessManager) getLoggerFromContext(ctx context.Context) logr.Logger {
 	return log.EnrichLoggerWithContext(ctx, m.rootLogger)
 }

--- a/pkg/bpm/bpm.go
+++ b/pkg/bpm/bpm.go
@@ -210,7 +210,11 @@ func (m *BackgroundProcessManager) recycle(uid string) {
 func (m *BackgroundProcessManager) StartProcess(ctx context.Context, cmd *ManagedCommand) (*Process, error) {
 	log := m.getLoggerFromContext(ctx)
 	if cmd.Identifier != nil {
-		_, loaded := m.identifiers.LoadOrStore(*cmd.Identifier, true)
+		// Reserve the identifier slot with a sentinel empty string so that any
+		// concurrent StartProcess call with the same identifier still bails out,
+		// but successful starts will overwrite the slot with the real UID below —
+		// enabling idempotent reuse via GetUidByIdentifier.
+		_, loaded := m.identifiers.LoadOrStore(*cmd.Identifier, "")
 		if loaded {
 			return nil, errors.Errorf("process with identifier %s is running", *cmd.Identifier)
 		}
@@ -218,11 +222,20 @@ func (m *BackgroundProcessManager) StartProcess(ctx context.Context, cmd *Manage
 
 	process, err := startProcess(cmd)
 	if err != nil {
+		// roll back the identifier reservation so the next call can retry
+		if cmd.Identifier != nil {
+			m.identifiers.Delete(*cmd.Identifier)
+		}
 		return nil, err
 	}
 
 	m.processes.Store(process.Uid, process)
 	m.pidPairToUid.Store(process.Pair, process.Uid)
+	if cmd.Identifier != nil {
+		// Now that we have a UID, replace the sentinel with the real UID so
+		// callers can recover the running process (and its pipes) on retry.
+		m.identifiers.Store(*cmd.Identifier, process.Uid)
+	}
 	// end
 
 	if m.metricsCollector != nil {
@@ -324,6 +337,30 @@ func (m *BackgroundProcessManager) GetIdentifiers() []string {
 	})
 
 	return identifiers
+}
+
+// GetUidByIdentifier returns the UID of the running process registered under
+// the given identifier. The second return value is false when no process with
+// that identifier is currently tracked, or when the slot is still in the
+// reserved-but-not-started state (sentinel empty string). This enables callers
+// such as ApplyHttpChaos to recover the existing process on retry instead of
+// failing with "process with identifier ... is running".
+func (m *BackgroundProcessManager) GetUidByIdentifier(identifier string) (string, bool) {
+	v, loaded := m.identifiers.Load(identifier)
+	if !loaded {
+		return "", false
+	}
+	uid, ok := v.(string)
+	if !ok || uid == "" {
+		return "", false
+	}
+	// Make sure the process is actually still tracked. The deathChannel goroutine
+	// deletes the identifier on process exit, but we double-check to guard
+	// against any caller having raced with recycle.
+	if _, ok := m.processes.Load(uid); !ok {
+		return "", false
+	}
+	return uid, true
 }
 
 func (m *BackgroundProcessManager) getLoggerFromContext(ctx context.Context) logr.Logger {

--- a/pkg/bpm/bpm_test.go
+++ b/pkg/bpm/bpm_test.go
@@ -261,4 +261,100 @@ var _ = Describe("background process manager", func() {
 			}, time.Second*3, time.Millisecond*100).Should(BeFalse())
 		})
 	})
+
+	// IsProcessAlive + EvictProcess back the "stale recovery" defense in
+	// ApplyHttpChaos: when the host pod is deleted out from under us the
+	// death-channel cleanup may not fire promptly, leaving a stale BPM entry
+	// whose pipe FDs would block forever on write. Callers use
+	// IsProcessAlive to decide whether to trust a recovered uid, and
+	// EvictProcess to drop a stale entry without sending SIGTERM (since the
+	// process is already gone).
+	Context("liveness check and eviction", func() {
+		It("IsProcessAlive returns true while the process runs and false after it exits", func() {
+			cmd := DefaultProcessBuilder("sleep", "0.2").Build(context.Background())
+			p, err := m.StartProcess(context.Background(), cmd)
+			Expect(err).To(BeNil())
+
+			// While alive: must report alive.
+			Expect(m.IsProcessAlive(p.Uid)).To(BeTrue())
+
+			// After exit: deathChannel will eventually remove the entry, at
+			// which point IsProcessAlive returns false because the uid is
+			// no longer tracked.
+			Eventually(func() bool {
+				return m.IsProcessAlive(p.Uid)
+			}, time.Second*3, time.Millisecond*50).Should(BeFalse())
+		})
+
+		It("IsProcessAlive returns false after the host process is killed bypassing BPM", func() {
+			// Spawn a sleep we can SIGKILL without going through BPM, to
+			// simulate the host pod's namespace teardown reaping tproxy
+			// before the deathChannel goroutine drains.
+			cmd := DefaultProcessBuilder("sleep", "30").Build(context.Background())
+			p, err := m.StartProcess(context.Background(), cmd)
+			Expect(err).To(BeNil())
+
+			Expect(m.IsProcessAlive(p.Uid)).To(BeTrue())
+
+			// Reach around BPM and SIGKILL the process directly.
+			Expect(p.Cmd.Process.Kill()).To(Succeed())
+
+			// IsProcessAlive must report false even though BPM may not have
+			// observed the death yet (the deathChannel goroutine drains
+			// asynchronously). This is exactly the ApplyHttpChaos
+			// stale-recovery scenario.
+			Eventually(func() bool {
+				return m.IsProcessAlive(p.Uid)
+			}, time.Second*3, time.Millisecond*50).Should(BeFalse())
+		})
+
+		It("IsProcessAlive returns false for an unknown uid", func() {
+			Expect(m.IsProcessAlive("never-registered-uid")).To(BeFalse())
+		})
+
+		It("EvictProcess unregisters the uid + identifier so a fresh start can re-register", func() {
+			identifier := RandomeIdentifier()
+			cmd := DefaultProcessBuilder("sleep", "30").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			p, err := m.StartProcess(context.Background(), cmd)
+			Expect(err).To(BeNil())
+
+			// Sanity: identifier is in use, so a second start must fail.
+			cmd2 := DefaultProcessBuilder("sleep", "1").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			_, err = m.StartProcess(context.Background(), cmd2)
+			Expect(err).NotTo(BeNil())
+			Expect(strings.Contains(err.Error(), "is running")).To(BeTrue())
+
+			// Evict the original (still actually running, but pretend it's
+			// stale). All three internal maps must be cleared.
+			m.EvictProcess(p.Uid)
+
+			_, ok := m.GetUidByIdentifier(identifier)
+			Expect(ok).To(BeFalse())
+			_, ok = m.GetUID(p.Pair)
+			Expect(ok).To(BeFalse())
+			_, ok = m.GetPipes(p.Uid)
+			Expect(ok).To(BeFalse())
+
+			// And a fresh start on the same identifier now succeeds.
+			cmd3 := DefaultProcessBuilder("sleep", "0.2").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			p3, err := m.StartProcess(context.Background(), cmd3)
+			Expect(err).To(BeNil())
+
+			// Cleanup: kill the still-running first process (we evicted its
+			// BPM record but the OS process is alive).
+			Expect(p.Cmd.Process.Kill()).To(Succeed())
+			WaitProcess(m, p3, time.Second*3)
+		})
+
+		It("EvictProcess on an unknown uid is a no-op", func() {
+			// Must not panic.
+			m.EvictProcess("never-registered-uid")
+		})
+	})
 })

--- a/pkg/bpm/bpm_test.go
+++ b/pkg/bpm/bpm_test.go
@@ -187,4 +187,78 @@ var _ = Describe("background process manager", func() {
 			WaitProcess(m, p, time.Second*0)
 		})
 	})
+
+	// Regression test for the HTTPChaos retry bug:
+	//
+	//   On a retried ApplyHttpChaos gRPC call, the daemon previously
+	//   re-invoked StartProcess with the same `tproxy-<containerId>`
+	//   identifier, was rejected with "process with identifier ... is
+	//   running", and had no way to recover the UID/pipes of the live
+	//   tproxy. GetUidByIdentifier closes that gap.
+	Context("get uid by identifier", func() {
+		It("returns the live UID so ApplyHttpChaos can recover on retry", func() {
+			identifier := RandomeIdentifier()
+
+			// First start: succeeds and registers identifier -> uid.
+			cmd1 := DefaultProcessBuilder("sleep", "5").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			p1, err := m.StartProcess(context.Background(), cmd1)
+			Expect(err).To(BeNil())
+
+			// Look up by identifier -- the regression: must return p1's UID
+			// and not be empty (which is what would force createHttpChaos to
+			// re-spawn and trip "is running").
+			uid, ok := m.GetUidByIdentifier(identifier)
+			Expect(ok).To(BeTrue())
+			Expect(uid).To(Equal(p1.Uid))
+
+			// Second start with the same identifier still must fail (the
+			// no-double-spawn invariant), but the caller now has a way to
+			// recover: GetUidByIdentifier still returns the same UID, and
+			// GetPipes on it gives back usable pipes.
+			cmd2 := DefaultProcessBuilder("sleep", "5").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			_, err = m.StartProcess(context.Background(), cmd2)
+			Expect(err).NotTo(BeNil())
+			Expect(strings.Contains(err.Error(), "is running")).To(BeTrue())
+
+			uid2, ok2 := m.GetUidByIdentifier(identifier)
+			Expect(ok2).To(BeTrue())
+			Expect(uid2).To(Equal(uid))
+
+			pipes, ok3 := m.GetPipes(uid2)
+			Expect(ok3).To(BeTrue())
+			Expect(pipes.Stdin).NotTo(BeNil())
+			Expect(pipes.Stdout).NotTo(BeNil())
+
+			// Cleanup so we don't leak the sleep process or its identifier.
+			err = m.KillBackgroundProcess(context.Background(), uid)
+			Expect(err).To(BeNil())
+			WaitProcess(m, p1, time.Second*0)
+		})
+
+		It("returns false for an unknown or already-exited identifier", func() {
+			_, ok := m.GetUidByIdentifier("never-registered-identifier")
+			Expect(ok).To(BeFalse())
+
+			identifier := RandomeIdentifier()
+			cmd := DefaultProcessBuilder("sleep", "0").
+				SetIdentifier(identifier).
+				Build(context.Background())
+			p, err := m.StartProcess(context.Background(), cmd)
+			Expect(err).To(BeNil())
+
+			WaitProcess(m, p, time.Second*3)
+
+			// Once the process has exited, the death-channel goroutine
+			// removes the identifier; lookups must miss instead of returning
+			// a dangling UID.
+			Eventually(func() bool {
+				_, ok := m.GetUidByIdentifier(identifier)
+				return ok
+			}, time.Second*3, time.Millisecond*100).Should(BeFalse())
+		})
+	})
 })

--- a/pkg/chaosdaemon/httpchaos_server.go
+++ b/pkg/chaosdaemon/httpchaos_server.go
@@ -44,16 +44,34 @@ type stdioTransport struct {
 	pipes  bpm.Pipes
 }
 
+// stdioMu returns the per-uid mutex that serializes RoundTrip writes/reads on
+// the same tproxy stdio. The mutex is created on first access and shared via
+// the daemon-scoped sync.Map (DaemonServer.tproxyLocker), so all
+// stdioTransport instances built for the same uid block on the same lock.
+func (t *stdioTransport) stdioMu() *sync.Mutex {
+	mu, _ := t.locker.LoadOrStore(t.uid, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
 func (t *stdioTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	if _, loaded := t.locker.LoadOrStore(t.uid, true); loaded {
-		return &http.Response{
-			StatusCode: http.StatusLocked,
-			Status:     http.StatusText(http.StatusLocked),
-			Body:       io.NopCloser(bytes.NewBufferString("")),
-			Request:    req,
-		}, nil
-	}
-	defer t.locker.Delete(t.uid)
+	// Serialize concurrent reconciles for the same tproxy.
+	//
+	// Multiple controller-manager replicas (and the same controller's own
+	// reconcile loop firing on resource updates) can call ApplyHttpChaos
+	// concurrently for the same pod. The tproxy stdio is a single bidirectional
+	// pipe -- two callers writing requests at the same time would interleave
+	// bytes mid-frame and corrupt both responses. The original implementation
+	// fast-failed concurrent callers with 423 Locked; the controller then
+	// surfaced that as "Apply failed" and overwrote the previous reconcile's
+	// success in PodHttpChaos.Status, leaving injectedCount stuck at 0 even
+	// though the chaos was actually applied. Block on a per-uid mutex instead;
+	// every caller writes its own request, reads its own response, and returns
+	// 200. The mutex is allocated on first access via LoadOrStore so concurrent
+	// allocations don't race.
+	mu := t.stdioMu()
+	mu.Lock()
+	defer mu.Unlock()
+
 	if t.pipes.Stdin == nil {
 		return nil, errors.New("fail to get stdin of process")
 	}

--- a/pkg/chaosdaemon/httpchaos_server.go
+++ b/pkg/chaosdaemon/httpchaos_server.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -36,6 +37,15 @@ import (
 const (
 	tproxyBin = "/usr/local/bin/tproxy"
 	pathEnv   = "PATH"
+
+	// httpChaosRoundTripTimeout caps a single tproxy stdio request/response
+	// cycle. If the underlying tproxy process is dead or unresponsive, the
+	// stdin write or stdout read can block indefinitely; without a cap the
+	// per-uid mutex in stdioTransport.RoundTrip would never release and every
+	// subsequent reconcile would deadlock at Lock(). The cap is intentionally
+	// shorter than typical gRPC-client deadlines so the caller can return a
+	// clean error and let the controller retry / evict.
+	httpChaosRoundTripTimeout = 5 * time.Second
 )
 
 type stdioTransport struct {
@@ -51,6 +61,39 @@ type stdioTransport struct {
 func (t *stdioTransport) stdioMu() *sync.Mutex {
 	mu, _ := t.locker.LoadOrStore(t.uid, &sync.Mutex{})
 	return mu.(*sync.Mutex)
+}
+
+// RoundTripCtx is the context-aware entry point. It runs RoundTrip in a
+// goroutine, then either returns its result or, if the context fires first,
+// returns a deadline-exceeded error.
+//
+// Why this matters: if the underlying tproxy process has died but BPM still
+// has its pipe FDs (e.g. the host pod was deleted out from under us), a
+// stdin write or stdout read can block forever. Without a deadline the
+// per-uid mutex held by RoundTrip would never release, and every subsequent
+// reconcile would deadlock at Lock() and then time out at the gRPC layer
+// with "context canceled" events on the CR.
+//
+// Note: the spawned goroutine still holds the mutex if its I/O hangs. The
+// caller (ApplyHttpChaos) is responsible for evicting the BPM entry on
+// timeout so subsequent calls re-spawn a fresh tproxy under a fresh uid
+// (and thus a different mutex), instead of queueing behind the dead one.
+func (t *stdioTransport) RoundTripCtx(ctx context.Context, req *http.Request) (*http.Response, error) {
+	type result struct {
+		resp *http.Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := t.RoundTrip(req)
+		done <- result{resp: resp, err: err}
+	}()
+	select {
+	case r := <-done:
+		return r.resp, r.err
+	case <-ctx.Done():
+		return nil, errors.Wrapf(ctx.Err(), "tproxy stdio roundtrip aborted (uid=%s)", t.uid)
+	}
 }
 
 func (t *stdioTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
@@ -116,8 +159,23 @@ func (s *DaemonServer) ApplyHttpChaos(ctx context.Context, in *pb.ApplyHttpChaos
 	// Look up the live tproxy process directly by its identifier and reuse it.
 	if in.InstanceUid == "" && in.ContainerId != "" {
 		if uid, ok := s.backgroundProcessManager.GetUidByIdentifier(httpChaosIdentifier(in.ContainerId)); ok {
-			log.Info("recovered existing tproxy", "uid", uid, "containerId", in.ContainerId)
-			in.InstanceUid = uid
+			// Live-check before trusting the recovered uid. If the host pod
+			// was deleted and replaced (StatefulSet rollout, eviction, etc.)
+			// the original tproxy is gone but the deathChannel cleanup may
+			// not have fired yet (e.g. cmd.Wait stuck across the namespace
+			// teardown, or the controller hit us before the chan drained).
+			// Trusting a stale uid sends RoundTrip into a dead pipe that
+			// blocks forever, which then deadlocks every subsequent
+			// reconcile via the per-uid mutex.
+			if s.backgroundProcessManager.IsProcessAlive(uid) {
+				log.Info("recovered existing tproxy", "uid", uid, "containerId", in.ContainerId)
+				in.InstanceUid = uid
+			} else {
+				log.Info("stale tproxy entry, evicting and respawning",
+					"uid", uid, "containerId", in.ContainerId)
+				s.backgroundProcessManager.EvictProcess(uid)
+				// fall through to createHttpChaos below
+			}
 		}
 	}
 
@@ -193,8 +251,22 @@ func (s *DaemonServer) applyHttpChaos(ctx context.Context, in *pb.ApplyHttpChaos
 		return nil, errors.Wrap(err, "create http request")
 	}
 
-	resp, err := transport.RoundTrip(req)
+	// Cap the stdio roundtrip with our own deadline. Use the more restrictive
+	// of the caller's gRPC ctx and our internal cap: never block longer than
+	// httpChaosRoundTripTimeout, but exit early if the gRPC client gives up
+	// first. On timeout we evict the BPM entry so the next reconcile starts
+	// fresh -- otherwise the in-flight goroutine pins the per-uid mutex
+	// behind a dead pipe and every subsequent caller deadlocks too.
+	rtCtx, cancel := context.WithTimeout(ctx, httpChaosRoundTripTimeout)
+	defer cancel()
+
+	resp, err := transport.RoundTripCtx(rtCtx, req)
 	if err != nil {
+		if rtCtx.Err() != nil {
+			log.Info("tproxy unresponsive, evicting BPM entry so next reconcile respawns",
+				"uid", in.InstanceUid, "timeout", httpChaosRoundTripTimeout)
+			s.backgroundProcessManager.EvictProcess(in.InstanceUid)
+		}
 		return nil, errors.Wrap(err, "send http request")
 	}
 

--- a/pkg/chaosdaemon/httpchaos_server.go
+++ b/pkg/chaosdaemon/httpchaos_server.go
@@ -70,12 +70,35 @@ func (t *stdioTransport) RoundTrip(req *http.Request) (resp *http.Response, err 
 	return
 }
 
+// httpChaosIdentifier returns the BPM identifier under which the tproxy
+// process for a given container is registered. Keeping it as a single helper
+// lets ApplyHttpChaos and createHttpChaos agree on the exact key to look up.
+func httpChaosIdentifier(containerID string) string {
+	return fmt.Sprintf("tproxy-%s", containerID)
+}
+
 func (s *DaemonServer) ApplyHttpChaos(ctx context.Context, in *pb.ApplyHttpChaosRequest) (*pb.ApplyHttpChaosResponse, error) {
 	log := s.getLoggerFromContext(ctx)
 	log.Info("applying http chaos")
 
 	if in.InstanceUid == "" {
 		if uid, ok := s.backgroundProcessManager.GetUID(bpm.ProcessPair{Pid: int(in.Instance), CreateTime: in.StartTime}); ok {
+			in.InstanceUid = uid
+		}
+	}
+
+	// Idempotency: if the controller / RPC retries (which it routinely does
+	// while the PodHttpChaos status update lands), the InstanceUid the caller
+	// sends is empty and the (Pid, StartTime) reverse lookup misses for any of
+	// the usual reasons (zero-valued status fields, daemon-side restart, race
+	// with the controller's deferred status update). Without recovery, the next
+	// createHttpChaos call would fail with "process with identifier
+	// tproxy-<containerId> is running" and HTTPChaos would be stuck at
+	// injectedCount=0 forever even though tproxy is healthy inside the pod.
+	// Look up the live tproxy process directly by its identifier and reuse it.
+	if in.InstanceUid == "" && in.ContainerId != "" {
+		if uid, ok := s.backgroundProcessManager.GetUidByIdentifier(httpChaosIdentifier(in.ContainerId)); ok {
+			log.Info("recovered existing tproxy", "uid", uid, "containerId", in.ContainerId)
 			in.InstanceUid = uid
 		}
 	}
@@ -180,7 +203,7 @@ func (s *DaemonServer) createHttpChaos(ctx context.Context, in *pb.ApplyHttpChao
 	}
 	processBuilder := bpm.DefaultProcessBuilder(tproxyBin, "-i", "-vv").
 		EnableLocalMnt().
-		SetIdentifier(fmt.Sprintf("tproxy-%s", in.ContainerId)).
+		SetIdentifier(httpChaosIdentifier(in.ContainerId)).
 		SetEnv(pathEnv, os.Getenv(pathEnv))
 
 	if in.EnterNS {

--- a/pkg/chaosdaemon/httpchaos_server_test.go
+++ b/pkg/chaosdaemon/httpchaos_server_test.go
@@ -17,17 +17,21 @@ package chaosdaemon
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/chaos-mesh/chaos-mesh/pkg/bpm"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
 	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
@@ -123,6 +127,93 @@ var _ = Describe("http chaos server", func() {
 
 			// Cleanup: kill the fake tproxy so the suite exits.
 			Expect(s.backgroundProcessManager.KillBackgroundProcess(context.TODO(), resp1.InstanceUid)).To(Succeed())
+		})
+	})
+
+	// Regression test for the concurrent-RoundTrip 423 bug:
+	//
+	//   Multiple controller-manager replicas (and the same controller's
+	//   reconcile loop firing on resource updates) call ApplyHttpChaos
+	//   concurrently for the same pod. The tproxy stdio is one bidirectional
+	//   pipe; the original code fast-failed concurrent callers with
+	//   StatusLocked (423), which the controller surfaced as
+	//   "Apply failed: status(423)" and used to overwrite the previous
+	//   reconcile's success in PodHttpChaos.Status. Net effect: chaos was
+	//   applied but injectedCount stayed at 0. The fix serializes concurrent
+	//   RoundTrip on a per-uid mutex; every caller eventually writes its own
+	//   request, gets its own 200 response, and surfaces success.
+	Context("RoundTrip concurrency on the same tproxy stdio (regression)", func() {
+		It("serializes concurrent calls and returns 200 for both, never 423", func() {
+			// Synthetic tproxy: one goroutine reads requests off the
+			// stdin-pipe and writes 200 responses to the stdout-pipe.
+			stdinR, stdinW := io.Pipe()
+			stdoutR, stdoutW := io.Pipe()
+
+			// fake tproxy: serve one HTTP request per loop iteration.
+			tproxyDone := make(chan struct{})
+			go func() {
+				defer close(tproxyDone)
+				br := bufio.NewReader(stdinR)
+				for {
+					req, err := http.ReadRequest(br)
+					if err != nil {
+						return
+					}
+					_, _ = io.Copy(io.Discard, req.Body)
+					_ = req.Body.Close()
+					_, _ = fmt.Fprint(stdoutW, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+				}
+			}()
+
+			locker := &sync.Map{}
+			transport := &stdioTransport{
+				uid:    "regression-uid",
+				locker: locker,
+				pipes:  bpm.Pipes{Stdin: stdinW, Stdout: stdoutR},
+			}
+
+			// Drive N concurrent RoundTrips against the same transport.
+			// Without the fix every goroutine after the first one would
+			// observe locker.LoadOrStore(uid, true) -> loaded==true and
+			// return 423; with the fix the per-uid mutex serializes them.
+			const concurrency = 16
+			var wg sync.WaitGroup
+			statuses := make([]int, concurrency)
+			errs := make([]error, concurrency)
+			for i := 0; i < concurrency; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					req, err := http.NewRequest(http.MethodPut, "/", bytes.NewReader([]byte("{}")))
+					if err != nil {
+						errs[i] = err
+						return
+					}
+					resp, err := transport.RoundTrip(req)
+					if err != nil {
+						errs[i] = err
+						return
+					}
+					statuses[i] = resp.StatusCode
+					_ = resp.Body.Close()
+				}(i)
+			}
+
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			Eventually(done, 5*time.Second).Should(BeClosed(),
+				"all concurrent RoundTrip calls must drain; if any deadlocked the lock implementation is wrong")
+
+			for i := 0; i < concurrency; i++ {
+				Expect(errs[i]).To(BeNil(), "RoundTrip #%d returned error", i)
+				Expect(statuses[i]).To(Equal(http.StatusOK),
+					"RoundTrip #%d returned %d; concurrent reconciles must not see 423", i, statuses[i])
+			}
+
+			// Tear down the fake tproxy.
+			stdinW.Close()
+			stdoutW.Close()
+			<-tproxyDone
 		})
 	})
 })

--- a/pkg/chaosdaemon/httpchaos_server_test.go
+++ b/pkg/chaosdaemon/httpchaos_server_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package chaosdaemon
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/crclients/test"
+	"github.com/chaos-mesh/chaos-mesh/pkg/chaosdaemon/pb"
+	"github.com/chaos-mesh/chaos-mesh/pkg/log"
+	"github.com/chaos-mesh/chaos-mesh/pkg/mock"
+)
+
+// fakeTproxyEnv is the env var that, when set, tells the test binary to act as
+// a stand-in for the real /usr/local/bin/tproxy: read an HTTP request off
+// stdin, write a 200 OK reply on stdout, and stay alive so subsequent
+// ApplyHttpChaos calls can find it via the BPM identifier registry.
+const fakeTproxyEnv = "GO_HELPER_FAKE_TPROXY"
+
+func init() {
+	if os.Getenv(fakeTproxyEnv) != "" {
+		runFakeTproxy()
+		os.Exit(0)
+	}
+}
+
+func runFakeTproxy() {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		req, err := http.ReadRequest(reader)
+		if err != nil {
+			return
+		}
+		// Drain & discard the request body so the reader is positioned at
+		// the next request frame.
+		_, _ = io.Copy(io.Discard, req.Body)
+		_ = req.Body.Close()
+		fmt.Fprint(os.Stdout, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+	}
+}
+
+var _ = Describe("http chaos server", func() {
+	defer mock.With("MockContainerdClient", &test.MockClient{})()
+	logger, err := log.NewDefaultZapLogger()
+	Expect(err).To(BeNil())
+	s, _ := newDaemonServer(&crclients.CrClientConfig{
+		Runtime: crclients.ContainerRuntimeContainerd}, nil, logger)
+
+	Context("ApplyHttpChaos idempotency on retry (regression)", func() {
+		It("a second ApplyHttpChaos with the same containerId reuses the existing tproxy", func() {
+			Expect(s).NotTo(BeNil(), "newDaemonServer must build with the mocked containerd client")
+
+			defer mock.With("pid", 9527)()
+
+			// Counter for how many times the daemon paths through the
+			// process builder. The bug: every retried RPC re-spawns. The
+			// fix: only the first call spawns; subsequent ones reuse via
+			// GetUidByIdentifier.
+			var spawnCount int32
+			defer mock.With("MockProcessBuild", func(ctx context.Context, cmd string, args ...string) *exec.Cmd {
+				atomic.AddInt32(&spawnCount, 1)
+				// Re-exec the test binary with the fake-tproxy env var so
+				// it speaks HTTP over stdio just like the real tproxy.
+				c := exec.Command(os.Args[0])
+				c.Env = append(os.Environ(), fakeTproxyEnv+"=1")
+				return c
+			})()
+
+			req := &pb.ApplyHttpChaosRequest{
+				Rules:       "[]",
+				ProxyPorts:  []uint32{8080},
+				ContainerId: "containerd://regression-container-id",
+				EnterNS:     true,
+			}
+
+			resp1, err := s.ApplyHttpChaos(context.TODO(), req)
+			Expect(err).To(BeNil())
+			Expect(resp1).NotTo(BeNil())
+			Expect(resp1.InstanceUid).NotTo(BeEmpty())
+
+			// Simulate the controller's retry pattern: it doesn't persist
+			// InstanceUid back to the CR status, so the next reconcile
+			// sends an empty UID for the same containerId.
+			req2 := &pb.ApplyHttpChaosRequest{
+				Rules:       "[]",
+				ProxyPorts:  []uint32{8080},
+				ContainerId: "containerd://regression-container-id",
+				EnterNS:     true,
+			}
+			resp2, err := s.ApplyHttpChaos(context.TODO(), req2)
+			Expect(err).To(BeNil(), "second ApplyHttpChaos must not return 'process with identifier ... is running'")
+			Expect(resp2).NotTo(BeNil())
+
+			// Same tproxy instance -- this is what unblocks injectedCount.
+			Expect(resp2.InstanceUid).To(Equal(resp1.InstanceUid))
+
+			// Trip-wire stayed armed: only one spawn ever happened.
+			Expect(atomic.LoadInt32(&spawnCount)).To(Equal(int32(1)))
+
+			// Cleanup: kill the fake tproxy so the suite exits.
+			Expect(s.backgroundProcessManager.KillBackgroundProcess(context.TODO(), resp1.InstanceUid)).To(Succeed())
+		})
+	})
+})

--- a/pkg/chaosdaemon/httpchaos_server_test.go
+++ b/pkg/chaosdaemon/httpchaos_server_test.go
@@ -216,4 +216,159 @@ var _ = Describe("http chaos server", func() {
 			<-tproxyDone
 		})
 	})
+
+	// Regression test for symptom 1 (deadlock) reported on byte-cluster:
+	//
+	//   When the host pod is deleted and replaced (StatefulSet rollout etc.),
+	//   the original tproxy process inside the old pod's net+pid namespaces is
+	//   gone, but BPM's deathChannel cleanup may not fire promptly -- leaving a
+	//   stale `(uid, pipes)` entry whose pipe FDs would block forever on write.
+	//   The next ApplyHttpChaos that recovered this stale uid would log
+	//   "ready to apply" and then deadlock inside RoundTrip, holding the
+	//   per-uid mutex; every subsequent reconcile would block at Lock().
+	//
+	// The fix: live-check via IsProcessAlive before trusting the recovered
+	// uid; if dead, EvictProcess and fall through to createHttpChaos.
+	Context("ApplyHttpChaos with stale BPM entry (regression: deadlock symptom 1)", func() {
+		It("detects a dead tproxy, evicts it, and respawns a fresh one", func() {
+			Expect(s).NotTo(BeNil(), "newDaemonServer must build with the mocked containerd client")
+
+			defer mock.With("pid", 9527)()
+
+			// Track every spawn so we can assert two distinct tproxies were
+			// born across the two ApplyHttpChaos calls.
+			var spawnCount int32
+			var spawnedCmds sync.Map // pid -> *exec.Cmd, populated post-Start
+			defer mock.With("MockProcessBuild", func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				atomic.AddInt32(&spawnCount, 1)
+				c := exec.Command(os.Args[0])
+				c.Env = append(os.Environ(), fakeTproxyEnv+"=1")
+				return c
+			})()
+
+			containerID := "containerd://stale-recovery-container-id"
+			req1 := &pb.ApplyHttpChaosRequest{
+				Rules:       "[]",
+				ProxyPorts:  []uint32{8080},
+				ContainerId: containerID,
+				EnterNS:     true,
+			}
+
+			resp1, err := s.ApplyHttpChaos(context.TODO(), req1)
+			Expect(err).To(BeNil())
+			Expect(resp1.InstanceUid).NotTo(BeEmpty())
+			firstUid := resp1.InstanceUid
+
+			// The first spawn happened; remember its pid so we can later
+			// assert the second spawn produced a different process.
+			spawnedCmds.Store("first", resp1.Instance)
+
+			// Kill the first fake-tproxy outside of BPM (simulating the
+			// host pod's namespace teardown reaping tproxy without
+			// chaos-daemon's deathChannel goroutine getting a chance to
+			// drain). We reach into BPM internals to grab the cmd.
+			proc, ok := s.backgroundProcessManager.GetPipes(firstUid)
+			Expect(ok).To(BeTrue())
+			_ = proc // keep the variable used; pipes are also relevant only insofar as the underlying process is gone
+
+			// Find the *Process in BPM and kill its underlying os.Process.
+			// We can't reach the cmd directly through public API, so find
+			// it via the same pid that was returned in resp1.
+			killByPid(int(resp1.Instance))
+
+			// Wait until the host kernel's reaped the process so
+			// IsProcessAlive returns false. Note: the deathChannel may or
+			// may not have drained by now; the test deliberately races to
+			// hit ApplyHttpChaos *before* it does (which is the bug
+			// scenario). IsProcessAlive must catch this regardless.
+			Eventually(func() bool {
+				return s.backgroundProcessManager.IsProcessAlive(firstUid)
+			}, 5*time.Second, 50*time.Millisecond).Should(BeFalse(),
+				"first fake tproxy must report dead after we killed it")
+
+			// Second ApplyHttpChaos for the SAME containerID. With the bug,
+			// recovery would trust the dead uid and RoundTrip would hang.
+			// With the fix, IsProcessAlive returns false, EvictProcess
+			// drops the stale entry, and createHttpChaos spawns a fresh
+			// tproxy under a new uid.
+			req2 := &pb.ApplyHttpChaosRequest{
+				Rules:       "[]",
+				ProxyPorts:  []uint32{8080},
+				ContainerId: containerID,
+				EnterNS:     true,
+			}
+			done := make(chan struct{})
+			var resp2 *pb.ApplyHttpChaosResponse
+			var err2 error
+			go func() {
+				defer close(done)
+				resp2, err2 = s.ApplyHttpChaos(context.TODO(), req2)
+			}()
+			Eventually(done, 10*time.Second).Should(BeClosed(),
+				"second ApplyHttpChaos must not deadlock when recovery hits a dead tproxy")
+			Expect(err2).To(BeNil())
+			Expect(resp2).NotTo(BeNil())
+			Expect(resp2.InstanceUid).NotTo(BeEmpty())
+			Expect(resp2.InstanceUid).NotTo(Equal(firstUid),
+				"a stale uid must be evicted, not reused; second call should mint a new uid")
+			Expect(atomic.LoadInt32(&spawnCount)).To(Equal(int32(2)),
+				"exactly two spawns: first is now stale + dead, second is the respawn")
+
+			// Cleanup the second fake tproxy.
+			Expect(s.backgroundProcessManager.KillBackgroundProcess(context.TODO(), resp2.InstanceUid)).To(Succeed())
+		})
+	})
+
+	// Regression test for the timeout half of symptom 1: even with the
+	// IsProcessAlive guard, RoundTrip itself must not block forever if
+	// tproxy is alive but unresponsive (e.g. wedged on a slow rule push).
+	// Without a deadline the per-uid mutex would still deadlock subsequent
+	// callers. RoundTripCtx caps the wait and returns ctx.Err() promptly.
+	Context("RoundTripCtx timeout (regression: deadlock symptom 1, slow path)", func() {
+		It("returns context.DeadlineExceeded when tproxy never reads stdin", func() {
+			// Pipe with no reader on the other side -- writes will block
+			// until the buffer fills, simulating an unresponsive tproxy.
+			stdinR, stdinW := io.Pipe()
+			_, stdoutW := io.Pipe()
+			defer stdinR.Close()
+			defer stdinW.Close()
+			defer stdoutW.Close()
+
+			locker := &sync.Map{}
+			transport := &stdioTransport{
+				uid:    "slow-tproxy-uid",
+				locker: locker,
+				pipes:  bpm.Pipes{Stdin: stdinW, Stdout: io.NopCloser(bytes.NewReader(nil))},
+			}
+
+			req, err := http.NewRequest(http.MethodPut, "/", bytes.NewReader([]byte("{}")))
+			Expect(err).To(BeNil())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			start := time.Now()
+			_, err = transport.RoundTripCtx(ctx, req)
+			elapsed := time.Since(start)
+
+			Expect(err).NotTo(BeNil(),
+				"RoundTripCtx must surface an error when tproxy is unresponsive")
+			Expect(elapsed).To(BeNumerically("<", 2*time.Second),
+				"RoundTripCtx must return promptly on timeout, not block")
+			// Underlying ctx.Err() should be DeadlineExceeded, wrapped.
+			Expect(ctx.Err()).To(Equal(context.DeadlineExceeded))
+		})
+	})
 })
+
+// killByPid sends SIGKILL to the host process at the given pid. Used by the
+// stale-recovery test to bypass BPM's KillBackgroundProcess (which would
+// trigger deathChannel cleanup) and simulate the host pod's namespace
+// teardown reaping tproxy out from under chaos-daemon.
+func killByPid(pid int) {
+	osProc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = osProc.Kill()
+}


### PR DESCRIPTION
## Root cause(s)

This PR fixes **three bugs on the same code path** that together kept HTTPChaos stuck at `phase: Not Injected/Wait, injectedCount: 0` (or, after later commits, deadlocked the daemon entirely) even though the chaos was actually applied inside the pod.

### Bug 1: `ApplyHttpChaos` not idempotent on retry (commit `648ee0b4`)

Every reconcile after the first failed with `process with identifier tproxy-<containerID> is running`. Investigation in `pkg/chaosdaemon/httpchaos_server.go` and `pkg/bpm/`:

1. `PodHttpChaos.Status` only persists `Pid` and `StartTime`, not `InstanceUid`. `controllers/podhttpchaos/controller.go` reads back `res.Instance`/`res.StartTime` after each `ApplyHttpChaos` but throws away `res.InstanceUid`. So the next reconcile cannot pass UID back to the daemon.
2. The daemon's fallback `GetUID(ProcessPair{Pid, CreateTime})` reverse-lookup misses on retry whenever the controller re-fires before the status update lands (zero values on read), or after a chaos-daemon restart wipes BPM in-memory state.
3. So `GetPipes("")` is not-ok, and `createHttpChaos` is invoked again. The first call left `tproxy-<containerId>` registered in `bpm.identifiers`, so the second `StartProcess` hits the `LoadOrStore`-already-loaded path and errors out before ever spawning a process.

**Fix**:
- `pkg/bpm/bpm.go`: `identifiers` now stores `identifier -> uid` (was `identifier -> bool`). The "is running" trip-wire stays armed by reserving the slot with a sentinel empty string at `StartProcess` entry; on success the slot is overwritten with the real UID; on `startProcess` error the reservation is rolled back. New `GetUidByIdentifier` recovers the live UID and double-checks the process is still tracked.
- `pkg/chaosdaemon/httpchaos_server.go`: in `ApplyHttpChaos`, after the existing `InstanceUid` passthrough and (Pid, StartTime) reverse lookup, fall through to `GetUidByIdentifier("tproxy-<containerId>")`. If a tproxy for this container is already registered, recover its UID and reuse its pipes — never re-enter `createHttpChaos`.

Concurrency invariant preserved: `StartProcess` still rejects a second `LoadOrStore` on the same identifier with the same `is running` error.

### Bug 2: concurrent `RoundTrip` returns 423, controller reads it as "Apply failed" (commit `5b2a9256`)

After Bug 1 was fixed, byte-cluster validation showed `recovered existing tproxy` + `http chaos applied` in chaos-daemon logs (chaos was actually injected) — but the CR still showed `injectedCount: 0` with 19 `Failed Apply` events of the form `failed to apply for pod ts20/...: status(423)`.

Root cause: with 3 controller-manager replicas (and the same controller's reconcile loop firing on resource updates), multiple `ApplyHttpChaos` calls hit the same tproxy stdio concurrently. The original `stdioTransport.RoundTrip` (in `pkg/chaosdaemon/httpchaos_server.go`) used `locker.LoadOrStore(uid, true)` to fast-fail concurrent callers with `StatusLocked` (423). The first call won the lock, sent its request, returned 200, applied the rules. Every subsequent concurrent call observed `loaded=true`, returned 423 with empty body, and the controller surfaced this as `Apply failed: status(423)` — which then overwrote the previous reconcile's success in `PodHttpChaos.Status`.

**Fix**: `pkg/chaosdaemon/httpchaos_server.go` — replace the `LoadOrStore`-as-set pattern with a per-uid `*sync.Mutex` allocated lazily via `LoadOrStore(uid, &sync.Mutex{})` (race-free first-creator-wins). Concurrent callers now serialize on `Lock`/`Unlock`, each writes its own request, reads its own response, gets 200 back. The mutex lives on the same `DaemonServer.tproxyLocker` field (no struct change).

### Bug 3: stale tproxy recovery wedges `RoundTrip`, deadlocks the mutex chain (commit `1f9e1ae8`)

Byte-cluster validation of `5b2a9256` then surfaced a new failure mode:

- chaos-daemon log stopped at `ready to apply`, never reached `http chaos applied`. Every subsequent reconcile timed out at the gRPC layer with `context canceled` events.
- After deleting the host pod and waiting for replacement, the daemon still emitted `recovered existing tproxy { uid: <OLD> }` — but `ps` inside the new pod showed no tproxy.

Root cause: BPM's `deathChannel` cleanup goroutine drains async on `cmd.Wait()`. When the host pod's namespaces tear down, tproxy is reaped by the kernel but `cmd.Wait()` may not return promptly (e.g. across PID-namespace teardown), leaving a stale `(uid, pipes)` entry. `GetUidByIdentifier` happily returns it, `RoundTrip` writes to pipe FDs whose other end is gone, the write blocks forever, the per-uid mutex stays locked, every subsequent reconcile deadlocks at `Lock()`.

**Fix** (this commit):
1. `pkg/bpm/bpm.go` — two new primitives:
   - `IsProcessAlive(uid)`: checks `/proc/<pid>` exists AND its create-time matches the stored `ProcessPair.CreateTime` (defends against PID reuse).
   - `EvictProcess(uid)`: mirrors `deathChannel` cleanup without sending SIGTERM, since the OS process is already gone.
2. `pkg/chaosdaemon/httpchaos_server.go` — `ApplyHttpChaos` recovery path live-checks before trusting the recovered uid. If dead, log `stale tproxy entry, evicting and respawning`, call `EvictProcess`, fall through to `createHttpChaos`.
3. `pkg/chaosdaemon/httpchaos_server.go` — new `RoundTripCtx` wraps `RoundTrip` with `context.WithTimeout(ctx, 5s)`. On timeout `ApplyHttpChaos` evicts the BPM entry so the next reconcile spawns a fresh tproxy under a new uid + a different mutex, breaking the deadlock chain. (The pinned I/O goroutine on the dead pipe is a one-shot leak per stale entry, not a continuing deadlock.)

## Tests

All pure-Go, no Kubernetes cluster required.

**`pkg/bpm/bpm_test.go`** (existing + new specs, 13 total):
- `GetUidByIdentifier` returns the live UID after first `StartProcess`; second start with the same identifier fails (`is running` invariant) but lookup keeps returning the live UID and pipes stay usable. Also covers the exited-process recycle case.
- `IsProcessAlive` returns true while running, false after exit (death-channel drained), false after the host process is killed bypassing BPM (covers Bug 3 symptom 2: death-channel hasn't drained yet), false for unknown uid.
- `EvictProcess` unregisters identifier + uid + pidPair, allowing a fresh start to re-register; no-op for unknown uid.

**`pkg/chaosdaemon/httpchaos_server_test.go`** (4 specs):
1. **"a second ApplyHttpChaos with the same containerId reuses the existing tproxy"** — covers Bug 1. Two consecutive calls succeed, return same `InstanceUid`, exactly 1 spawn.
2. **"RoundTrip concurrency on the same tproxy stdio (regression)"** — covers Bug 2. 16 concurrent `RoundTrip` calls all return 200, none 423, no deadlock.
3. **"ApplyHttpChaos with stale BPM entry (regression: deadlock symptom 1)"** — covers Bug 3 stale-recovery half. Kill fake tproxy via `os.Process.Kill` bypassing BPM, call `ApplyHttpChaos` again, assert no deadlock (Eventually within 10s), different `InstanceUid` returned (stale evicted, fresh spawned), exactly 2 spawns total.
4. **"RoundTripCtx timeout (regression: deadlock symptom 1, slow path)"** — covers Bug 3 timeout half. `io.Pipe` with no reader, 100ms ctx, `RoundTripCtx` returns under 2s with `context.DeadlineExceeded` wrapped.

## Live validation

- Bug 1 fix verified live on byte-cluster `ts20` — chaos-daemon log shows `recovered existing tproxy ... http chaos applied`.
- Bug 2 fix verified by the new concurrency unit test (16 concurrent reconciles all return 200).
- Bug 3 fix pending byte-cluster re-test on `1f9e1ae8`. Validation tests cover both stale-recovery and timeout paths.

## Surfaced images

Built from this branch's HEAD (`1f9e1ae8`):

- `docker.io/opspai/chaos-daemon:fix-httpchaos-1f9e1ae8` (pushed)
- `docker.io/opspai/chaos-mesh:fix-httpchaos-1f9e1ae8` (pushed)

`pair-cn-shanghai.cr.volces.com/opspai/*` is an auto-mirror of `docker.io`, so the docker.io push is the canonical artifact.

`helm upgrade` validation:

```
helm upgrade --reuse-values chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh \
  --set chaosDaemon.image.repository=docker.io/opspai/chaos-daemon \
  --set chaosDaemon.image.tag=fix-httpchaos-1f9e1ae8 \
  --set controllerManager.image.repository=docker.io/opspai/chaos-mesh \
  --set controllerManager.image.tag=fix-httpchaos-1f9e1ae8
```

Note: chaos-daemon image was built as an overlay on `ghcr.io/chaos-mesh/chaos-daemon:latest` (so it inherits tproxy/byteman/nsexec already shipped there) and only swaps in the patched `chaos-daemon` and `cdh` binaries. See `images/chaos-daemon/Dockerfile.fix` for the build context. The full proper Dockerfile (`images/chaos-daemon/Dockerfile`) was not used because the build environment couldn't reach `github.com` for the tproxy/nsexec/byteman release downloads; once the team rebuilds via `make image-chaos-daemon` from a network-reachable build env that should be the canonical artifact.

## Related

- Closes #4
- Companion sync issue: #5 (the fork is 45 commits behind `chaos-mesh/chaos-mesh` upstream master; that sync is independent of this fix and requires `make proto` regen which this session couldn't do, so it's filed as a separate tracking issue rather than blended into this PR).